### PR TITLE
fix: clear handlers after every test

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -81,6 +81,8 @@ Cypress.Commands.add('mockWebSocket', (url: string, connectionResponseMessage?: 
   cy.on('test:after:run', () => {
     console.log("Mock Socket: Stopping Mock Server")
     mockServer.close()
+    requestResponses = []
+    requestHandlers = []
   })
 })
 


### PR DESCRIPTION
Handlers persisted across test runs and caused weird bugs.